### PR TITLE
When building on windows, can't point cmake to LIBRARY_PREFIX

### DIFF
--- a/recipe/cudatoolkit-dev-post-install.py
+++ b/recipe/cudatoolkit-dev-post-install.py
@@ -208,6 +208,27 @@ class WinExtractor(Extractor):
                         copy_tree(src, nvcc_dst)
                         
         os.remove(runfile)
+        
+        # create hard links of the whole toolkit into %LIBRARY_PREFIX%
+        self.create_hardlinks_into_prefix()
+
+    def create_hardlinks_into_prefix(self):
+        src_root = os.path.join(self.src_dir, "nvcc")
+        dst_root = os.path.join(self.prefix, "Library")
+        for root, dirs, files in os.walk(src_root):
+            current_dst_root = os.path.join(dst_root, os.path.relpath(root, src_root))
+
+            for d in dirs:
+                os.makedirs(os.path.join(current_dst_root, d), exist_ok=True)
+
+            for f in files:
+                dst_file = os.path.join(current_dst_root, f)
+                src_file = os.path.join(root, f)
+
+                # if dst_file does not exist yet, create a hard link
+                if not os.path.exists(dst_file):
+                    os.link(src_file, dst_file)
+                    #print("hard link: {} --> {}".format(src_file, dst_file))
 
 @contextmanager
 def _hdiutil_mount(mntpnt, image):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   script: python build.py {{ release }} {{ version_build }} {{ driver_version }}  # [linux]
   script: python build.py {{ release }} {{ version_build }} {{ win_driver_version }}  # [win]
-  number: 4
+  number: 5
   skip: True  # [osx]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

By now we can only point cmake with the `-T cuda=` option to the pkgs folder, but not to `LIBRARY_PREFIX` because the directory structure is not preserved. This PR additionally hard-links the original directory structure into LIBRARY_PREFIX so that it can be picked up by cmake.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
